### PR TITLE
Fixed print statement in btstat() function

### DIFF
--- a/ghome/ghome.py
+++ b/ghome/ghome.py
@@ -112,7 +112,7 @@ def bstat(ip):
   try:
     response = requests.request("GET", url).json()
     for key, value in response.items():
-        print key, value
+        print(key, value)
   except Exception as e:
     print(e)
 


### PR DESCRIPTION
Looks like the btstat function had an old style print statement, which causes an error when running ghome in Python 3.8. 

I updated this print statement to match the rest of the script.